### PR TITLE
Allow `main_label` to be a string

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ You can do it by sending special arguments to the component:
 ```php
 @include('backpack.language-switcher::LanguageSwitcher', [
     'flags' => true, // true by default, change it to hide flags
-    'main_label' => false, // false by default, change it to show the current locale label
+    'main_label' => false, // false by default, it may also be a string, for instance "Language"
 ])
 ```
 

--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -9,7 +9,7 @@
         @endif
         @if($main_label ?? false || (($flags ?? true) === false && !isset($main_label)))
         <span class="nav-link-title">
-            {{ $helper->getLocaleName($helper->getCurrentLocale()) }}
+            {{ is_string($main_label ?? false) ? $main_label : $helper->getLocaleName($helper->getCurrentLocale()) }}
         </span>
         @endif
     </a>


### PR DESCRIPTION
```php
@include('backpack.language-switcher::language-switcher', [
    'flags' => false,
    'main_label' => __('Locale'),
])
```

![image](https://github.com/Laravel-Backpack/language-switcher/assets/1838187/c89e269a-5762-4fa6-b781-3e16eb3d1ff8)
