### PR TITLE
Removed rule to validate the locale on route

### DIFF
--- a/routes/language-switcher.php
+++ b/routes/language-switcher.php
@@ -17,6 +17,5 @@ Route::group([
 ], function () {
     // set locale
     Route::any('set-locale/{locale}', [LanguageSwitcherController::class, 'setLocale'])
-        ->where('locale', '[a-z]{2}(-[a-zA-Z]{2})?')
         ->name('language-switcher.locale');
 });


### PR DESCRIPTION
Since there is unlimited options for the locale names, we're removing the rule.
Also, the locale is validated after on the controller.