### PR TITLE
Allow language switcher to work outside of the admin panel

### DIFF
--- a/routes/language-switcher.php
+++ b/routes/language-switcher.php
@@ -13,7 +13,7 @@ use Backpack\LanguageSwitcher\Http\Controllers\LanguageSwitcherController;
 */
 Route::group([
     'namespace' => 'Backpack\LanguageSwitcher\Http\Controllers',
-    'middleware' => ['web', config('backpack.base.middleware_key', 'admin'), 'throttle:60,1'],
+    'middleware' => ['web', 'throttle:60,1'],
 ], function () {
     // set locale
     Route::any('set-locale/{locale}', [LanguageSwitcherController::class, 'setLocale'])


### PR DESCRIPTION
This is a fix for https://github.com/Laravel-Backpack/language-switcher/issues/15.

The package was being "scoped" to the admin panel, we should not do it, developers may use it outside the admin panel 👌