### PR TITLE
ability to customize package routes

### DIFF
--- a/config/language-switcher.php
+++ b/config/language-switcher.php
@@ -2,7 +2,7 @@
 
 return [
     // when `false` developer should setup their own route for language switcher
-    // default: Route::any('{backpack_prefix?}/set-locale/{locale}', [\Backpack\LanguageSwitcher\Http\Controllers\LanguageSwitcherController::class, 'setLocale'])->name('language-switcher.locale')
+    // check the default route at /vendor/backpack/language-switcher/routes/language-switcher.php
     'setup_routes' => true,
 
     // when true, if the page where the picker is displayed use the `backpack route prefix` in the route, 

--- a/config/language-switcher.php
+++ b/config/language-switcher.php
@@ -8,5 +8,5 @@ return [
     // when true, if the page where the picker is displayed use the `backpack route prefix` in the route, 
     // we will also add the route prefix on the language-switcher route.
     // eg: https://domain.com/admin/set-locale/{locale} instead of https://domain.com/set-locale/{locale}
-    'use_backpack_route_prefix_on_admin_routes' => false,
+    'use_backpack_route_prefix' => false,
 ];

--- a/config/language-switcher.php
+++ b/config/language-switcher.php
@@ -5,8 +5,7 @@ return [
     // check the default route at /vendor/backpack/language-switcher/routes/language-switcher.php
     'setup_routes' => true,
 
-    // when true, if the page where the picker is displayed use the `backpack route prefix` in the route, 
-    // we will also add the route prefix on the language-switcher route.
+    // when true, we will add the route prefix on the language-switcher route.
     // eg: https://domain.com/admin/set-locale/{locale} instead of https://domain.com/set-locale/{locale}
     'use_backpack_route_prefix' => false,
 ];

--- a/config/language-switcher.php
+++ b/config/language-switcher.php
@@ -7,6 +7,6 @@ return [
 
     // when true, if the page where the picker is displayed use the `backpack route prefix` in the route, 
     // we will also add the route prefix on the language-switcher route.
-    // eg: https://your-application.com/admin/set-locale/{locale} and not https://your-application.com/set-locale/{locale} as default
+    // eg: https://domain.com/admin/set-locale/{locale} instead of https://domain.com/set-locale/{locale}
     'use_backpack_route_prefix_on_admin_routes' => false,
 ];

--- a/config/language-switcher.php
+++ b/config/language-switcher.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    // when `false` developer should setup their own route for language switcher
+    // default: Route::any('{backpack_prefix?}/set-locale/{locale}', [\Backpack\LanguageSwitcher\Http\Controllers\LanguageSwitcherController::class, 'setLocale'])->name('language-switcher.locale')
+    'setup_routes' => true,
+
+    // when true, if the page where the picker is displayed use the `backpack route prefix` in the route, 
+    // we will also add the route prefix on the language-switcher route.
+    // eg: https://your-application.com/admin/set-locale/{locale} and not https://your-application.com/set-locale/{locale} as default
+    'use_backpack_route_prefix_on_admin_routes' => false,
+];

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,9 @@ Try it right now, in [our online demo](https://demo.backpackforlaravel.com/admin
 
 ```bash
 composer require backpack/language-switcher
+
+# optional: publish the config file
+php artisan vendor:publish --provider="Backpack\LanguageSwitcher\LanguageSwitcherServiceProvider" --tag="config"
 ```
 
 2) Add the middleware to backpack config `config/backpack/base.php`:
@@ -77,6 +80,12 @@ protected $middlewareGroups = [
     ],
 ```
 
+### Can I customize the endpoint routes ? 
+**Yes!**
+You can do it by publishing the config file `php artisan vendor:publish --provider="Backpack\LanguageSwitcher\LanguageSwitcherServiceProvider" --tag="config"`.
+There you can totally disable the package route and register your own, or change some behavior related with display urls.
+
+Please take caution to protect the endpoint with throttling or any other security measure if you overwrite the routes. The default package route uses: `'throttle:60,1'`
 
 ## Notes
 

--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -15,7 +15,7 @@
     </a>
     <ul class="dropdown-menu dropdown-menu-right dropdown-menu-end" style="right: 0">
         @php
-            $useAdminPrefix = config('backpack.language-switcher.use_backpack_route_prefix_on_admin_routes');
+            $useAdminPrefix = config('backpack.language-switcher.use_backpack_route_prefix');
         @endphp
         @foreach(config('backpack.crud.locales', []) as $locale => $name)
         <li>

--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -16,7 +16,7 @@
     <ul class="dropdown-menu dropdown-menu-right dropdown-menu-end" style="right: 0">
         @foreach(config('backpack.crud.locales', []) as $locale => $name)
         <li>
-            <a class="dropdown-item {{ $locale === $helper->getCurrentLocale() ? 'active disabled' : '' }}" href="{{ route('language-switcher.locale', $locale) }}">
+            <a class="dropdown-item {{ $locale === $helper->getCurrentLocale() ? 'active disabled' : '' }}" href="{{ route('language-switcher.locale', ['locale' => $locale, 'backpack_prefix' => config('backpack.language-switcher.use_backpack_route_prefix_on_admin_routes') ? config('backpack.base.route_prefix') : null]) }}">
                 @if($flags ?? true)
                 <span class="nav-link-icon" style="width: fit-content">
                     <x-dynamic-component component="flag-{{ $helper->getFlagOrFallback($locale) }}" style="width: 1.5rem" />

--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -14,9 +14,16 @@
         @endif
     </a>
     <ul class="dropdown-menu dropdown-menu-right dropdown-menu-end" style="right: 0">
+        @php
+            $useAdminPrefix = config('backpack.language-switcher.use_backpack_route_prefix_on_admin_routes');
+        @endphp
         @foreach(config('backpack.crud.locales', []) as $locale => $name)
         <li>
-            <a class="dropdown-item {{ $locale === $helper->getCurrentLocale() ? 'active disabled' : '' }}" href="{{ route('language-switcher.locale', ['locale' => $locale, 'backpack_prefix' => config('backpack.language-switcher.use_backpack_route_prefix_on_admin_routes') ? config('backpack.base.route_prefix') : null]) }}">
+            <a class="dropdown-item {{ $locale === $helper->getCurrentLocale() ? 'active disabled' : '' }}" href="{{ route('language-switcher.locale', [
+                    'locale' => $useAdminPrefix ? $locale : null, 
+                    'backpack_prefix' => $useAdminPrefix ? config('backpack.base.route_prefix') : 'set-locale',
+                    'setLocale' => $useAdminPrefix ? 'set-locale' : $locale
+                ])}}">
                 @if($flags ?? true)
                 <span class="nav-link-icon" style="width: fit-content">
                     <x-dynamic-component component="flag-{{ $helper->getFlagOrFallback($locale) }}" style="width: 1.5rem" />

--- a/routes/language-switcher.php
+++ b/routes/language-switcher.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Route;
 | handled by the Backpack\LanguageSwitcher package.
 |
 */
-if(config('backpack.language-switcher.setup_routes')) {
+if(config('backpack.language-switcher.setup_routes', true)) {
     Route::group([
         'middleware' => ['web', 'throttle:60,1'],
     ], function () {

--- a/routes/language-switcher.php
+++ b/routes/language-switcher.php
@@ -14,8 +14,10 @@ if(config('backpack.language-switcher.setup_routes', true)) {
         'middleware' => ['web', 'throttle:60,1'],
     ], function () {
         // set locale
-        Route::any('{backpack_prefix?}/set-locale/{locale}', [\Backpack\LanguageSwitcher\Http\Controllers\LanguageSwitcherController::class, 'setLocale'])
-            ->name('language-switcher.locale')->where('backpack_prefix', config('backpack.base.route_prefix'));
+        Route::any('{backpack_prefix?}/{setLocale}/{locale?}', [\Backpack\LanguageSwitcher\Http\Controllers\LanguageSwitcherController::class, 'setLocale'])
+            ->name('language-switcher.locale')
+            ->whereIn('setLocale', array_merge(['set-locale'],array_keys(config('backpack.crud.locales'))))
+            ->whereIn('backpack_prefix', ['set-locale', config('backpack.base.route_prefix')]);
     });
 }
 

--- a/routes/language-switcher.php
+++ b/routes/language-switcher.php
@@ -1,7 +1,5 @@
 <?php
-
-use Backpack\LanguageSwitcher\Http\Controllers\LanguageSwitcherController;
-
+use Illuminate\Support\Facades\Route;
 /*
 |--------------------------------------------------------------------------
 | Backpack\LanguageSwitcher Routes
@@ -11,11 +9,13 @@ use Backpack\LanguageSwitcher\Http\Controllers\LanguageSwitcherController;
 | handled by the Backpack\LanguageSwitcher package.
 |
 */
-Route::group([
-    'namespace' => 'Backpack\LanguageSwitcher\Http\Controllers',
-    'middleware' => ['web', 'throttle:60,1'],
-], function () {
-    // set locale
-    Route::any('set-locale/{locale}', [LanguageSwitcherController::class, 'setLocale'])
-        ->name('language-switcher.locale');
-});
+if(config('backpack.language-switcher.setup_routes')) {
+    Route::group([
+        'middleware' => ['web', 'throttle:60,1'],
+    ], function () {
+        // set locale
+        Route::any('{backpack_prefix?}/set-locale/{locale}', [\Backpack\LanguageSwitcher\Http\Controllers\LanguageSwitcherController::class, 'setLocale'])
+            ->name('language-switcher.locale')->where('backpack_prefix', config('backpack.base.route_prefix'));
+    });
+}
+

--- a/src/Http/Controllers/LanguageSwitcherController.php
+++ b/src/Http/Controllers/LanguageSwitcherController.php
@@ -16,12 +16,14 @@ class LanguageSwitcherController extends Controller
     /**
      * Set's the app locale
      */
-    public function setLocale(string $locale): Redirector | RedirectResponse
+    public function setLocale(?string $backpackPrefix = null, ?string $setLocale = null, ?string $locale = null): Redirector | RedirectResponse
     {
+        $locale ??= $setLocale;
+
         if (in_array($locale, array_keys(config('backpack.crud.locales')))) {
             Session::put('backpack.language-switcher.locale', $locale);
         }
 
-        return redirect(url()->previous());
+        return redirect()->back();
     }
 }


### PR DESCRIPTION
We got a request to customize the package routes in #17 

It was kind of expected since we use named routes that can't be overwritten by registering developer routes before the package ones.

A good practice in this cases is to have a configuration that allow the developers to disable package route registering and they register the routes themselves. 

I've implemented that in this PR, but I went a little bit deeper on the real issue here. 

I think the fact that you are in `https://something.com/my-application/dasboard` and you change the language in `https://something.com/set-locale/pt` instead of `https://something.com/my-application/set-local/pt` is a little bit weird. 

I introduced a new configuration and tweaked the route a little bit, so that if developer enable `use_backpack_route_prefix_on_admin_routes`, if the current route has the admin prefix, we also add the admin prefix in the "set locale route". 

Let me know what you think @promatik 